### PR TITLE
Removed middleware checks for updating bookings #31

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -275,14 +275,10 @@ app.get(
 //-----------------//
 // Update a Stall  //
 //-----------------//
-app.put(
-	"/bookings/:id",
-	roleMiddleware(["admin", "finance", "allocator", "super"]),
-	async (req, res) => {
-		await Stall.findOneAndUpdate({ _id: ObjectId(req.params.id) }, req.body);
-		res.send({ message: "Stall updated." });
-	}
-);
+app.put("/bookings/:id", async (req, res) => {
+	await Stall.findOneAndUpdate({ _id: ObjectId(req.params.id) }, req.body);
+	res.send({ message: "Stall updated." });
+});
 
 //-----------------//
 // Delete a Stall  //


### PR DESCRIPTION
It's no longer a requirement for the user to be a member of staff in order to update a stall booking. Now the user can update one of their bookings without getting a 403 error.

**Stall Holder sees this:**

https://user-images.githubusercontent.com/56947241/205898132-91bb6eeb-1085-4eae-800e-ff0642dc21bd.mp4

